### PR TITLE
Update tags api preview, fix stateful loop with `by` attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "svelte-array-helper": "^2.0.2"
   },
   "devDependencies": {
-    "@marko/tags-api-preview": "^0.0.12",
+    "@marko/tags-api-preview": "^0.0.13",
     "@marko/webpack": "^7.1.2",
     "@types/compression": "^1.7.0",
     "@types/express": "^4.17.11",
@@ -38,7 +38,8 @@
     "typescript": "^4.2.3",
     "webpack": "^4.36.1",
     "webpack-cli": "^3.3.6",
-    "webpack-dev-server": "^3.7.2"
+    "webpack-dev-server": "^3.7.2",
+    "webpack-node-externals": "^3.0.0"
   },
   "homepage": "https://github.com/JoshuaAmaju/marko-typescript",
   "license": "MIT",

--- a/src/home/components/home.marko
+++ b/src/home/components/home.marko
@@ -1,7 +1,7 @@
 import { push, pop, splice } from '../utils'
 
 <let/arr=[]/>
-<let/count=0 />
+<let/lastId=0/>
 
 <style>
     li::before {
@@ -12,16 +12,15 @@ import { push, pop, splice } from '../utils'
 <effect() {
     console.log(arr)
 } />
-
 <ul>
-    <for|i| of=arr>
+    <for|id, i| of=arr by=(id => id)>
         <let/count=0/>
 
         <effect() {
-            console.log('i', i)
+            console.log('i', id)
         } />
 
-        <li data-count=i>
+        <li data-count=id>
             <p>${count}</p>
 
             <button onClick() {
@@ -33,7 +32,7 @@ import { push, pop, splice } from '../utils'
             }>+</button>
 
             <button onClick() {
-                console.log(i);
+                console.log(id);
                 arr = splice(arr, i, 1);
             }>remove</button>
         </li>
@@ -46,7 +45,7 @@ import { push, pop, splice } from '../utils'
 }>-</button>
 
 <button onClick() {
-    arr = push(arr, [...arr].length + 1)
+    arr = push(arr, lastId++)
 }>+</button>
 
 // BELOW IS ALSO AND EXAMPLE OF THE MAP ISSUE

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ const path = require("path");
 const webpack = require("webpack");
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 const MarkoPlugin = require("@marko/webpack/plugin").default;
+const nodeExternals = require('webpack-node-externals');
 const CSSExtractPlugin = require("mini-css-extract-plugin");
 const SpawnServerPlugin = require("spawn-server-webpack-plugin");
 const OptimizeCssAssetsPlugin = require("optimize-css-assets-webpack-plugin");
@@ -47,7 +48,13 @@ module.exports = [
   compiler({
     name: "Server",
     target: "async-node",
-    externals: [/^[^./!]/], // excludes node_modules
+    externals: [
+      // Exclude node_modules, but ensure non js files are bundled.
+      // Eg: `.marko`, `.css`, etc.
+      nodeExternals({
+          allowlist: [/\.(?!(?:js|json)$)[^.]+$/]
+      })
+    ],
     optimization: {
       minimize: false,
     },


### PR DESCRIPTION
This PR contains a few changes.

1. Updates the tags api preview to fix a bug around loop keying that would cause internal state to be reset.
2. Adds the `webpack-node-externals` tool to the webpack setup to allow SSR marko files in the `node_modules` (not sure how this was working before).

Besides those two small changes this also updates the loop to use the new `by` attribute which tells Marko how to keep track of individual items within a loop (replaces the `key` attribute on tags within a loop).